### PR TITLE
Assign Dependabot pull requests to robinpellegrims

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       time: "09:00"
       timezone: "Europe/Brussels"
     open-pull-requests-limit: 10
+    assignees:
+      - "robinpellegrims"
     cooldown:
       default-days: 5
       semver-major-days: 30


### PR DESCRIPTION
## Summary
- Add `robinpellegrims` as the assignee for Dependabot pull requests in `.github/dependabot.yml`
- Keeps dependency update PRs routed to the right owner automatically

## Testing
- Not run (not requested)